### PR TITLE
Fix an error when pressing enter in the input before entering any text

### DIFF
--- a/spec/bootstrap-tags-spec.coffee
+++ b/spec/bootstrap-tags-spec.coffee
@@ -66,6 +66,15 @@ describe "Bootstrap Tags", ->
           readOnly: true
         expect($('#tagger2 .tags').html()).toEqual $('#tagger2').tags().readOnlyEmptyMessage
 
+  describe "when the enter key is pressed before any text is entered", ->
+
+    beforeEach ->
+      @tags = newTagger "tagger2", {}
+      $('#tagger2 .tags-input').trigger($.Event('keydown', which: 13))
+
+    it "does not add any tags", ->
+      expect(@tags.getTags()).toEqual []
+
   describe "when normally operating", ->
 
     beforeEach ->

--- a/src/bootstrap-tags.coffee
+++ b/src/bootstrap-tags.coffee
@@ -181,7 +181,7 @@ jQuery ->
           e.preventDefault()
           @pressedReturn(e)
           tag = e.target.value
-          if @suggestedIndex != -1
+          if @suggestedIndex? && @suggestedIndex != -1
             tag = @suggestionList[@suggestedIndex]
           @addTag tag
           e.target.value = ''


### PR DESCRIPTION
Fix an issue where you would get a `TypeError: _this.suggestedIndex is undefined` if you pressed enter in the input before entering any text

![enter-error](https://cloud.githubusercontent.com/assets/349804/5150696/e77ae464-71a2-11e4-8e38-83eb7000e4a2.png)
