### PR TITLE
Issue #51 - click removal of tags failing when tag contains special html characters

### DIFF
--- a/src/bootstrap-tags.coffee
+++ b/src/bootstrap-tags.coffee
@@ -95,7 +95,7 @@ jQuery ->
     # removeTagClicked is called when user clicks remove tag anchor (x)
     @removeTagClicked = (e) => # 
       if e.currentTarget.tagName == "A"
-        @removeTag $("span", e.currentTarget.parentElement).html()
+        @removeTag $("span", e.currentTarget.parentElement).text()
         $(e.currentTarget.parentNode).remove()
       @
 


### PR DESCRIPTION
#51

Fixed bug where tag removal via click failed when the tag contained special html characters such as '&amp;'.

Explanation: When fetching the text from the tag to splice it from the array, the jquery `.html()` method is used which automatically converts special characters such as `&` to `&amp;`. This makes the check-if-in-tags-array condition fail as the strings no longer match. Using the jquery .text() method prevents this conversion from happening.
