### PR TITLE
Don't hideSuggestions on scroll

### DIFF
--- a/src/bootstrap-tags.coffee
+++ b/src/bootstrap-tags.coffee
@@ -380,7 +380,7 @@ jQuery ->
     @addDocumentListeners = =>
       $(document).mouseup (e) =>
         container = @$('.tags-suggestion-list')
-        if container.has(e.target).length == 0
+        if container.has(e.target).length == 0 && !$(e.target).hasClass('tags-suggestion-list')
           @hideSuggestions()
 
     @template = (name, options) ->


### PR DESCRIPTION
When we scroll suggestions by drag & drop, `hideSuggestions` is called because of `mouseup`.

![scroll](https://cloud.githubusercontent.com/assets/2487437/21536797/ccc14b1e-cdca-11e6-9d0d-b43e3c4f9c42.gif)

So I fixed that not to call `hideSuggestions` if event target is suggestions list div.